### PR TITLE
Adds git garbage collection to chef-git-client

### DIFF
--- a/lib/chef_git/expand_node_object.rb
+++ b/lib/chef_git/expand_node_object.rb
@@ -48,8 +48,8 @@ class ChefGit::ExpandNodeObject < Chef::PolicyBuilder::ExpandNodeObject
   end
 
   def setup_run_context(specific_recipes=nil)
-    check_out_git
     cleanup_git if Time.now.hour == 3
+    check_out_git
 
     # We need to act like :solo = true but not actually set it.
     begin

--- a/lib/chef_git/expand_node_object.rb
+++ b/lib/chef_git/expand_node_object.rb
@@ -19,6 +19,13 @@ class ChefGit::ExpandNodeObject < Chef::PolicyBuilder::ExpandNodeObject
     end
   end
 
+  def cleanup_git
+    repo = Pathname.new('/var/chef/git')
+    Dir.chdir(repo) do
+      git('remote', 'prune', 'origin')
+      git('gc', '--auto', '--aggressive')
+    end
+  end
 
   def check_out_git
     return if @git_repo
@@ -42,6 +49,7 @@ class ChefGit::ExpandNodeObject < Chef::PolicyBuilder::ExpandNodeObject
 
   def setup_run_context(specific_recipes=nil)
     check_out_git
+    cleanup_git if Time.now.hour == 3
 
     # We need to act like :solo = true but not actually set it.
     begin

--- a/lib/chef_git/expand_node_object.rb
+++ b/lib/chef_git/expand_node_object.rb
@@ -3,6 +3,9 @@ require 'librarian/chef/cli'
 require 'pathname'
 
 class ChefGit::ExpandNodeObject < Chef::PolicyBuilder::ExpandNodeObject
+
+  REPO_PATH = '/var/chef/git'
+
   class CommandFailed < StandardError
     attr_reader :command, :status
 
@@ -20,8 +23,7 @@ class ChefGit::ExpandNodeObject < Chef::PolicyBuilder::ExpandNodeObject
   end
 
   def cleanup_git
-    repo = Pathname.new('/var/chef/git')
-    Dir.chdir(repo) do
+    Dir.chdir(REPO_PATH) do
       git('remote', 'prune', 'origin')
       git('gc', '--auto', '--aggressive')
     end
@@ -29,7 +31,7 @@ class ChefGit::ExpandNodeObject < Chef::PolicyBuilder::ExpandNodeObject
 
   def check_out_git
     return if @git_repo
-    repo = Pathname.new('/var/chef/git')
+    repo = Pathname.new(REPO_PATH)
     Dir.chdir(repo) do
       git('fetch', 'origin')
       git('reset', '--hard')


### PR DESCRIPTION
While @dwradcliffe was updating cooker he ran into a inodes issue. I did a file count check and found that the chef-git-client cookbooks folder was rather large and a lot of it was in the `.git` folder.  I ran garbage collection on it `git gc` and here are the before and after results,
```
root@chef:/var/chef# sudo find . -xdev -type f | cut -d "/" -f 2 | sort | uniq -c | sort -n
      1 lock
      4 handlers
    452 backup
   1588 cache
  53455 git

root@chef:/var/chef# sudo find . -xdev -type f | cut -d "/" -f 2 | sort | uniq -c | sort -n
      1 lock
      4 handlers
    452 backup
   1588 cache
  14438 git
```

As such I added a more aggressive gc call.  With the `--auto` flag it should only run if it needs to so it shouldn't slow things down if it needs too. Its hardcoded to only run if the hour is 0300 which means it would run once per day (but twice in an hour) which I think is aggressive enough

r @dwradcliffe @baldowl @kvs @stonith 