### PR TITLE
Branched data bags

### DIFF
--- a/lib/chef_git/branched_data_bag.rb
+++ b/lib/chef_git/branched_data_bag.rb
@@ -1,0 +1,40 @@
+require 'chef/node'
+require 'mixlib/shellout'
+
+module ChefGit::BranchedDataBag
+  extend self
+
+  def bag_name(data_bag)
+    if chef_git_environment == 'master'
+      return data_bag
+    elsif data_bag_changed?(data_bag)
+      return "#{chef_git_environment}__#{data_bag}"
+    else
+      return data_bag
+    end
+  end
+
+  private
+
+  def data_bag_changed?(data_bag)
+    Dir.chdir(ChefGit::REPO_PATH) do
+      git_diff = Mixlib::ShellOut.new("git diff origin/master data_bags/#{data_bag}")
+      git_diff.run_command
+      unchanged = !git_diff.error? && git_diff.stdout.empty? && git_diff.stderr.empty?
+      return !unchanged
+    end
+  end
+
+  def chef_git_environment
+    @branch ||= begin
+      # If the branch is specified in client.rb or -E flag, use that
+      if Chef::Config.environment
+        Chef::Config.environment
+      # Otherwise, look up the node
+      else
+        node = Chef::Node.load(Chef::Config[:node_name])
+        node.chef_environment
+      end
+    end
+  end
+end

--- a/lib/chef_git/data_bag_item.rb
+++ b/lib/chef_git/data_bag_item.rb
@@ -1,13 +1,20 @@
+require 'chef_git/branched_data_bag'
 require 'chef/encrypted_data_bag_item'
-
-# We are forcing chef solo mode so that we use the plain data bag items from git
-# If the items are encrypted, we use the chef server
-# https://github.com/chef/chef/blob/db57131ad383076391b9df32d5e9989cfb312d58/lib/chef/data_bag_item.rb#L149-L156
 
 class ChefGit::DataBagItem < Chef::DataBagItem
 
   def self.load(data_bag, name)
-    Chef::Config[:solo_legacy_mode] = chef_git_use_solo?(data_bag, name)
+    # We are forcing chef solo mode so that we use the plain data bag items from git
+    # If the items are encrypted, we use the chef server
+    # https://github.com/chef/chef/blob/db57131ad383076391b9df32d5e9989cfb312d58/lib/chef/data_bag_item.rb#L149-L156
+
+    use_solo = chef_git_use_solo?(data_bag, name)
+    unless use_solo
+      # If we aren't using solo, we'll see if we need to prefix our data bag with a branch
+      data_bag = ChefGit::BranchedDataBag.bag_name(data_bag)
+    end
+
+    Chef::Config[:solo_legacy_mode] = use_solo
     result = super
     Chef::Config[:solo_legacy_mode] = false
     return result

--- a/spec/lib/branched_data_bag_spec.rb
+++ b/spec/lib/branched_data_bag_spec.rb
@@ -1,0 +1,41 @@
+require File.expand_path('../../spec_helper.rb', __FILE__)
+
+RSpec.describe ChefGit::BranchedDataBag do
+
+  context 'is on master' do
+    before do
+      allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('master')
+    end
+
+    it 'returns the data bag name if on master' do
+      expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('foo')
+    end
+  end
+
+  context 'data bag differs from master' do
+    before do
+      allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return('something')
+      Dir.stub(:chdir).and_yield
+    end
+
+    it 'returns the data bag name prefixed by the branch' do
+      expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('notmaster__foo')
+    end
+  end
+
+  context 'data bag does not differ from master' do
+    before do
+      allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return('')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stderr).and_return('')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:error?).and_return(false)
+      Dir.stub(:chdir).and_yield
+    end
+
+    it 'returns the data bag name prefixed by the branch' do
+      expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('foo')
+    end
+
+  end
+end


### PR DESCRIPTION
# Why

If we are on a branch/environment, we want the chef server to decrypt the branch prefixed chef data bag for us. Otherwise, we will use the master data bag.

# How

We detect if we are on a branch, and if the the data bag is different from master if we are no a branch (using git diff).

* If we are not on a branch (on master), then we use the normal data bag name
* If we are on a branch and the data bag is different, we need the prefixed name
* If we are on a branch and the data bag is not different, we use the normal data bag name.

Also added some shitty tests for this.

@pallan @dwradcliffe @andrewjamesbrown for review