### PR TITLE
Allow branched data bags to be behind master

### DIFF
--- a/lib/chef_git/branched_data_bag.rb
+++ b/lib/chef_git/branched_data_bag.rb
@@ -18,9 +18,10 @@ module ChefGit::BranchedDataBag
 
   def data_bag_changed?(data_bag)
     Dir.chdir(ChefGit::REPO_PATH) do
-      git_diff = Mixlib::ShellOut.new("git diff origin/master data_bags/#{data_bag}")
+      git_diff = Mixlib::ShellOut.new("git rev-list --left-right --count origin/master...HEAD data_bags/#{data_bag}")
       git_diff.run_command
-      unchanged = !git_diff.error? && git_diff.stdout.empty? && git_diff.stderr.empty?
+      _master, branched = git_diff.stdout.split(/\s+/).map(&:to_i)
+      unchanged = !git_diff.error? && branched == 0
       return !unchanged
     end
   end

--- a/spec/lib/branched_data_bag_spec.rb
+++ b/spec/lib/branched_data_bag_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe ChefGit::BranchedDataBag do
     end
   end
 
-  context 'data bag differs from master' do
+  context 'branched data bag ahead of master' do
     before do
       allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
-      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return('something')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return("0\t3")
       Dir.stub(:chdir).and_yield
     end
 
@@ -24,16 +24,29 @@ RSpec.describe ChefGit::BranchedDataBag do
     end
   end
 
-  context 'data bag does not differ from master' do
+  context 'branched data bag matches master' do
     before do
       allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
-      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return('')
-      allow_any_instance_of(Mixlib::ShellOut).to receive(:stderr).and_return('')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return("0\t0")
       allow_any_instance_of(Mixlib::ShellOut).to receive(:error?).and_return(false)
       Dir.stub(:chdir).and_yield
     end
 
-    it 'returns the data bag name prefixed by the branch' do
+    it 'returns the data bag name not prefixed by branch branch' do
+      expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('foo')
+    end
+
+  end
+
+  context 'branched data bag behind master' do
+    before do
+      allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return("3\t0")
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:error?).and_return(false)
+      Dir.stub(:chdir).and_yield
+    end
+
+    it 'returns the data bag name not prefixed by branch branch' do
       expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('foo')
     end
 


### PR DESCRIPTION
# Why

Right now we assume that if the branched data bag is different than master, we should use an environment-prefixed data bag. This isn't a good assumption, because master can be ahead of the branch, and there is in fact no branch prefixed data bag.

# How

Instead of doing a simple diff, we compare revisions of the branch to see which branch actually has changes for the file. If master has changes, we'll use the master branch. If the branch has changes, we'll use the environment prefixed branch. If no change, we'll use the master branch. Note that if both branches has branches, we use the environment branch.

@andrewjamesbrown @dwradcliffe for review

cc @insom 