### PR TITLE
Ensure per-environment data-bag is on server

### DIFF
--- a/lib/chef_git/branched_data_bag.rb
+++ b/lib/chef_git/branched_data_bag.rb
@@ -8,7 +8,13 @@ module ChefGit::BranchedDataBag
     if chef_git_environment == 'master'
       return data_bag
     elsif data_bag_changed?(data_bag)
-      return "#{chef_git_environment}__#{data_bag}"
+      bag = "#{chef_git_environment}__#{data_bag}"
+      # Chef::DataBag.load returns an empty hash if the data bag is not on the server
+      if Chef::DataBag.load(bag).empty?
+        return data_bag
+      else
+        return bag
+      end
     else
       return data_bag
     end

--- a/spec/lib/branched_data_bag_spec.rb
+++ b/spec/lib/branched_data_bag_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ChefGit::BranchedDataBag do
     before do
       allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
       allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return("0\t3")
+      allow(Chef::DataBag).to receive(:load).and_return({'foo' => 'bar'})
       Dir.stub(:chdir).and_yield
     end
 
@@ -50,5 +51,33 @@ RSpec.describe ChefGit::BranchedDataBag do
       expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('foo')
     end
 
+  end
+
+  context 'branched data bag not on chef server' do
+    before do
+      allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return("0\t3")
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:error?).and_return(false)
+      allow(Chef::DataBag).to receive(:load).and_return({})
+      Dir.stub(:chdir).and_yield
+    end
+
+    it 'returns the data bag name not prefixed by branch branch' do
+      expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('foo')
+    end
+  end
+
+  context 'branched data bag on the chef server' do
+    before do
+      allow_any_instance_of(ChefGit::BranchedDataBag).to receive(:chef_git_environment).and_return('notmaster')
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:stdout).and_return("0\t3")
+      allow_any_instance_of(Mixlib::ShellOut).to receive(:error?).and_return(false)
+      allow(Chef::DataBag).to receive(:load).and_return({'foo' => 'bar'})
+      Dir.stub(:chdir).and_yield
+    end
+
+    it 'returns the data bag name prefixed by branch branch' do
+      expect(ChefGit::BranchedDataBag.bag_name('foo')).to eq('notmaster__foo')
+    end
   end
 end


### PR DESCRIPTION
In some cases, cooker doesn't upload the data bag, because it's
unchanged, but git history indicates changed commits.  Hence, we'll
check the server to ensure the data bag actually exists before sending
the environment-prefixed name to the caller.


r: @dalehamel @dwradcliffe 